### PR TITLE
Add missing requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Source code and full methodology for Outlier Ventures' Blockchain Developer Repo
 Requires Python.
 
 ```sh
-pip3 install pandas pygithub seaborn toml
+pip3 install pandas pygithub seaborn toml joblib
 ```
 
 ## Usage
 
-For all large data pulling operations, a [Github Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) is required.
+For all large data pulling operations, a [Github Personal Access Token (PAT)](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) is required. If you have private repos, be sure to use a token that only has the `public_repo` scope.
 
 ```sh
 export PAT=[YOUR_GITHUB_PAT]


### PR DESCRIPTION
PATs need scoped down if you have access to private repos in an org.

Signed-off-by: Ry Jones <ry@linux.com>